### PR TITLE
Add resume key persistence for codex restarts

### DIFF
--- a/agent-launch
+++ b/agent-launch
@@ -121,7 +121,9 @@ persist_codex_resume_key() {
 
     local resume_key
     resume_key="$(get_codex_resume_key "$tmux_name" 2>/dev/null || true)"
-    [ -n "$resume_key" ] || return 1
+    if ! is_valid_codex_resume_key "$resume_key"; then
+        return 1
+    fi
 
     upsert_session_field "$session_file" "resume_key" "$resume_key"
     echo "$resume_key"
@@ -396,7 +398,11 @@ cmd_start() {
     # This gives restart a deterministic key instead of relying on latest-session heuristics.
     local resume_key=""
     if [ "$AGENT_TYPE" = "codex" ] && [ "$use_branch" = false ]; then
-        resume_key="$(get_codex_resume_key "$tmux_name" 2>/dev/null || true)"
+        local discovered_resume_key
+        discovered_resume_key="$(get_codex_resume_key "$tmux_name" 2>/dev/null || true)"
+        if is_valid_codex_resume_key "$discovered_resume_key"; then
+            resume_key="$discovered_resume_key"
+        fi
     fi
 
     # Mode-specific setup
@@ -629,6 +635,9 @@ cmd_restart() {
     workdir="$(read_session_field "$session_file" workdir)"
     worktree="$(read_session_field "$session_file" worktree)"
     resume_key="$(read_session_field "$session_file" resume_key)"
+    if ! is_valid_codex_resume_key "$resume_key"; then
+        resume_key=""
+    fi
     ttyd_port="$(read_session_field "$session_file" ttyd_port)"
     ttyd_pid="$(read_session_field "$session_file" ttyd_pid)"
     saved_extra_args="$(read_session_field "$session_file" extra_args)"

--- a/tests/unit.t
+++ b/tests/unit.t
@@ -259,6 +259,20 @@ else
     test_fail "got: $CMD"
 fi
 
+test_start "is_valid_codex_resume_key accepts UUID-shaped key"
+if is_valid_codex_resume_key "123e4567-e89b-12d3-a456-426614174000"; then
+    test_pass
+else
+    test_fail "valid UUID-shaped resume key rejected"
+fi
+
+test_start "is_valid_codex_resume_key rejects non-UUID key"
+if is_valid_codex_resume_key "not-a-real-resume-key" >/dev/null 2>&1; then
+    test_fail "non-UUID resume key accepted"
+else
+    test_pass
+fi
+
 #------------------------------------------------------------------------------
 # Test: Task file discovery
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Summary
- keep Codex restarts going through resume flows that preserve default flags via `get_agent_cmd`
- capture and persist Codex resume keys so non-branch restarts can reuse the tmux session without forcing interactive prompts
- fall back to the `/resume` picker when no deterministic key/worktree is available so users can choose the correct session

Testing
- Not run (not requested)