### PR TITLE
Persist next round after completed cycles

### DIFF
--- a/agent-duo
+++ b/agent-duo
@@ -4684,6 +4684,9 @@ cmd_run() {
             fi
 
             round=$((round + 1))
+            # Persist next round so restarts continue from the next cycle
+            # instead of replaying the just-finished round.
+            echo "$round" > "$peer_sync/round"
         done
 
         if [ "$round" -gt "$max_rounds" ]; then

--- a/agent-pair
+++ b/agent-pair
@@ -2522,6 +2522,9 @@ cmd_run() {
         fi
 
         round=$((round + 1))
+        # Persist next round so restarts continue from the next cycle
+        # instead of replaying the just-finished round.
+        echo "$round" > "$peer_sync/round"
     done
 
     if [ "$round" -gt "$max_rounds" ]; then


### PR DESCRIPTION
Update both orchestrators to write the incremented round number to .peer-sync/round after each completed iteration. This makes restarts continue at N+1 after a finished round, avoiding same-round artifact overwrite/replay.